### PR TITLE
Fix TypeError, KeyError, login TypeError

### DIFF
--- a/hitbtc/connector.py
+++ b/hitbtc/connector.py
@@ -132,7 +132,7 @@ class HitBTCConnector(WebSocketConnectorThread):
             msg = response_types[method]
         except KeyError as e:
             log.exception(e)
-            log.error("Response's method %s is unknown to the client! %s", method)
+            log.error("Response's method %s is unknown to the client! %s", method, response)
             return
         print(request)
         if method.startswith('subscribe'):

--- a/hitbtc/connector.py
+++ b/hitbtc/connector.py
@@ -154,7 +154,10 @@ class HitBTCConnector(WebSocketConnectorThread):
             else:
                 # Format messages for these using response['result'] directly
                 # (place, cancel, replace, getSymbol, getCurrency)
-                text += msg.format(**response['result'])
+                try:
+                    text += msg.format(**response['result'])
+                except TypeError:
+                    text += msg.format(response['result'])
                 self.log.info(text)
                 self.echo(text)
         self.log.debug("Request: %r, Response: %r", request, response)

--- a/hitbtc/utils.py
+++ b/hitbtc/utils.py
@@ -111,6 +111,7 @@ resp_subscribe_book = 'Succesfully subscribed to {symbol} order book data!'
 resp_subscribe_trades = 'Succesfully subscribed to {symbol} trade data!'
 resp_subscribe_candles = 'Succesfully subscribed to {symbol} candle data!'
 resp_subscribe_reports = 'Succesfully subscribed to account reports!'
+resp_login = 'Successfully logged in!'
 
 response_types = {'getCurrency': resp_get_currency, 'getCurrencies': resp_get_currencies,
                   'getSymbol': resp_get_symbol, 'getSymbols': resp_get_symbols,
@@ -123,4 +124,5 @@ response_types = {'getCurrency': resp_get_currency, 'getCurrencies': resp_get_cu
                   'subscribeCandles': resp_subscribe_candles,
                   'subscribeReports': resp_subscribe_reports,
                   'newOrder': resp_place_order, 'cancelOrder': resp_cancel_order,
-                  'cancelReplaceOrder': resp_cancel_replace_order}
+                  'cancelReplaceOrder': resp_cancel_replace_order,
+                  'login' : resp_login}


### PR DESCRIPTION
TypeError: not enough arguments for format string

hitbtc/connector.py", line 135, in _handle_request_response
    log.error("Response's method %s is unknown to the client! %s", method)
Message: "Response's method %s is unknown to the client! %s"
Arguments: ('login',)